### PR TITLE
Fix CodeTabs: rollback to native TabItem

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,28 @@
+{
+    "arrowParens": "always",
+    "bracketSameLine": false,
+    "bracketSpacing": true,
+    "embeddedLanguageFormatting": "auto",
+    "htmlWhitespaceSensitivity": "css",
+    "insertPragma": false,
+    "jsxSingleQuote": false,
+    "printWidth": 80,
+    "proseWrap": "always",
+    "quoteProps": "as-needed",
+    "requirePragma": false,
+    "semi": true,
+    "singleAttributePerLine": false,
+    "singleQuote": false,
+    "tabWidth": 2,
+    "trailingComma": "es5",
+    "useTabs": false,
+    "vueIndentScriptAndStyle": false,
+    "plugins": [
+        "@trivago/prettier-plugin-sort-imports"
+    ],
+    "importOrder": [
+        "<THIRD_PARTY_MODULES>",
+        "^[./]"
+    ],
+    "importOrderSeparation": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+    "[json]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "vscode.json-language-features",
+        "files.insertFinalNewline": true
+    },
+    "[typescript]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[javascript]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescriptreact]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[mdx]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    }
+}

--- a/docs/tutorial/rag-with-vector-store.mdx
+++ b/docs/tutorial/rag-with-vector-store.mdx
@@ -1,36 +1,43 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeTabs from "@site/src/components/CodeTabs";
+import CodeTabs, { pythonTab, nodeTab } from "@site/src/components/CodeTabs";
+import TabItem from "@theme/TabItem";
 
 # RAG with Vector Store
 
-**Retrieval-Augmented Generation (RAG)** is a powerful method that enhances language models with external knowledge. Instead of relying solely on the model’s internal training data, RAG retrieves relevant documents from a knowledge base—typically a vector store—and injects them into the prompt at inference time. This allows the model to generate more accurate, up-to-date, and context-aware responses.
+**Retrieval-Augmented Generation (RAG)** is a powerful method that enhances
+language models with external knowledge. Instead of relying solely on the
+model’s internal training data, RAG retrieves relevant documents from a
+knowledge base—typically a vector store—and injects them into the prompt at
+inference time. This allows the model to generate more accurate, up-to-date, and
+context-aware responses.
 
 RAG is particularly useful when:
 
-* The knowledge base is too large to fit within the model’s context window.
-* Real-time or domain-specific information is needed.
-* You want to combine static model knowledge with dynamic data sources.
+- The knowledge base is too large to fit within the model’s context window.
+- Real-time or domain-specific information is needed.
+- You want to combine static model knowledge with dynamic data sources.
 
 ### Initializing a Vector Store
 
-Ailoy simplifies the construction of RAG pipelines through its built-in `VectorStore` component, which works alongside the `Agent`.
+Ailoy simplifies the construction of RAG pipelines through its built-in
+`VectorStore` component, which works alongside the `Agent`.
 
 To initialize a vector store:
 
 <CodeTabs>
-<CodeTabs.Python>
-```python
+<TabItem {...pythonTab}>
+
+```python showLineNumbers
 from ailoy import Runtime
 from ailoy.vectorstore import VectorStore, FAISSConfig
 
-rt = Runtime()
-with VectorStore(rt, FAISSConfig(embedding="bge-m3")) as vs:
+rt = Runtime() with VectorStore(rt, FAISSConfig(embedding="bge-m3")) as vs:
     ...
 ```
-</CodeTabs.Python>
-<CodeTabs.Nodejs>
-```typescript
+
+</TabItem>
+<TabItem {...nodeTab}>
+
+```typescript showLineNumbers
 import { createRuntime, VectorStore } from "ailoy-node";
 
 const rt = await createRuntime();
@@ -40,30 +47,37 @@ const vs = new VectorStore(rt, {
 });
 await vs.initialize();
 ```
-</CodeTabs.Nodejs>
+
+</TabItem>
 </CodeTabs>
 
-> Ailoy currently supports both [**FAISS**](https://github.com/facebookresearch/faiss) and [**ChromaDB**](https://www.trychroma.com/) as vector store backends.
-> Refer to the official configuration guide for backend-specific options.
+> Ailoy currently supports both
+> [**FAISS**](https://github.com/facebookresearch/faiss) and
+> [**ChromaDB**](https://www.trychroma.com/) as vector store backends. Refer to
+> the official configuration guide for backend-specific options.
 
-> 💡 **Note:** At this time, the only supported embedding model is [`bge-m3`](https://huggingface.co/BAAI/bge-m3).
-> Additional embedding models will be supported in future releases.
+> 💡 **Note:** At this time, the only supported embedding model is
+> [`bge-m3`](https://huggingface.co/BAAI/bge-m3). Additional embedding models
+> will be supported in future releases.
 
 ### Inserting Documents into the Vector Store
 
 You can insert text along with optional metadata into the vector store:
 
 <CodeTabs>
-<CodeTabs.Python>
-```python
+<TabItem {...pythonTab}>
+
+```python showLineNumbers
 vs.insert(
-    "Ailoy is a lightweight library for building AI applications", 
+    "Ailoy is a lightweight library for building AI applications",
     metadata={"topic": "Ailoy"}
 )
 ```
-</CodeTabs.Python>
-<CodeTabs.Nodejs>
-```typescript
+
+</TabItem>
+<TabItem {...nodeTab}>
+
+```typescript showLineNumbers
 await vs.insert({
   document: "Ailoy is a lightweight library for building AI applications",
   metadata: {
@@ -71,92 +85,117 @@ await vs.insert({
   },
 });
 ```
-</CodeTabs.Nodejs>
+
+</TabItem>
 </CodeTabs>
 
-In practice, you should split large documents into smaller chunks before inserting them. This improves retrieval quality. You may use any text-splitting tool (e.g., [LangChain](https://python.langchain.com/docs/concepts/text_splitters/)), or utilize Ailoy’s low-level runtime API for text splitting. (See [Calling Low-Level APIs](./calling-low-level-apis.md) for more details.)
+In practice, you should split large documents into smaller chunks before
+inserting them. This improves retrieval quality. You may use any text-splitting
+tool (e.g.,
+[LangChain](https://python.langchain.com/docs/concepts/text_splitters/)), or
+utilize Ailoy’s low-level runtime API for text splitting. (See
+[Calling Low-Level APIs](./calling-low-level-apis.md) for more details.)
 
 ### Retrieving Relevant Documents
 
 To retrieve documents similar to a given query:
 
 <CodeTabs>
-<CodeTabs.Python>
-```python
+<TabItem {...pythonTab}>
+
+```python showLineNumbers
 query = "What is Ailoy?"
-items = vs.retrieve(query, top_k=5)
+items =vs.retrieve(query, top_k=5)
 ```
-</CodeTabs.Python>
-<CodeTabs.Nodejs>
-```typescript
+
+</TabItem>
+<TabItem {...nodeTab}>
+
+```typescript showLineNumbers
 const query = "What is Ailoy?";
 const items = await vs.retrieve(query, 5);
 ```
-</CodeTabs.Nodejs>
+
+</TabItem>
 </CodeTabs>
 
-This returns a list of `VectorStoreRetrieveItem` instances representing the most relevant chunks, ranked by similarity. The number of results is controlled via the `top_k` parameter (default is 5).
+This returns a list of `VectorStoreRetrieveItem` instances representing the most
+relevant chunks, ranked by similarity. The number of results is controlled via
+the `top_k` parameter (default is 5).
 
 ### Constructing an Augmented Prompt
 
-Once documents are retrieved, you can construct a context-enriched prompt as follows:
+Once documents are retrieved, you can construct a context-enriched prompt as
+follows:
 
 <CodeTabs>
-<CodeTabs.Python>
-```python
+<TabItem {...pythonTab}>
+
+```python showLineNumbers
 prompt = f"""
     Based on the provided contexts, try to answer user's question.
     Context: {[item.document for item in items]}
     Question: {query}
 """
 ```
-</CodeTabs.Python>
-<CodeTabs.Nodejs>
-```typescript
+
+</TabItem>
+<TabItem {...nodeTab}>
+
+```typescript showLineNumbers
 const prompt = `
   Based on the provided contexts, try to answer user' question.
   Context: ${items.map((item) => item.document)}
   Question: ${query}
 `;
 ```
-</CodeTabs.Nodejs>
+
+</TabItem>
 </CodeTabs>
 
 You can then pass this prompt to the agent for inference:
 
 <CodeTabs>
-<CodeTabs.Python>
-```python
+<TabItem {...pythonTab}>
+
+```python showLineNumbers
 for resp in agent.run(prompt):
     print(resp.content, end='')
 print()
 ```
-</CodeTabs.Python>
-<CodeTabs.Nodejs>
-```typescript
+
+</TabItem>
+<TabItem {...nodeTab}>
+
+```typescript showLineNumbers
 for await (const resp of agent.run(prompt)) {
-    process.stdout.write(resp.content);
+  process.stdout.write(resp.content);
 }
 process.stdout.write("\n");
 ```
-</CodeTabs.Nodejs>
+
+</TabItem>
 </CodeTabs>
 
 ### Complete Example
 
 <CodeTabs>
-<CodeTabs.Python>
-```python
+<TabItem {...pythonTab}>
+
+```python showLineNumbers
 from ailoy import Runtime
 from ailoy.vectorstore import VectorStore, FAISSConfig
 
 # Initialize Runtime
+
 rt = Runtime()
+
 # Initialize Agent and VectorStore
+
 with Agent(rt, model_name="qwen3-8b") as agent, VectorStore(rt, FAISSConfig(embedding="bge-m3")) as vs:
     # Insert items
     vs.insert(
-        "Ailoy is a lightweight library for building AI applications", 
+        "Ailoy is a lightweight library for building AI applications",
         metadata={"topic": "Ailoy"}
     )
 
@@ -175,21 +214,20 @@ with Agent(rt, model_name="qwen3-8b") as agent, VectorStore(rt, FAISSConfig(embe
     for resp in agent.run(prompt):
         print(resp.content, end='')
     print()
+
 ```
-</CodeTabs.Python>
-<CodeTabs.Nodejs>
-```typescript
+
+</TabItem>
+<TabItem {...nodeTab}>
+
+```typescript showLineNumbers
 import { createRuntime, createAgent, createVectorStore } from "ailoy-node";
 
 async function main() {
   // Initialize Runtime
   const rt = await createRuntime();
   // Initialize Agent
-  const agent = await createAgent(rt, {
-    model: {
-      name: "qwen3-8b",
-    },
-  });
+  const agent = await createAgent(rt, { model: { name: "qwen3-8b" } });
   // Initialize VectorStore
   const vs = await createVectorStore(rt, {
     type: "faiss",
@@ -199,9 +237,7 @@ async function main() {
   // Insert items
   await vs.insert({
     document: "Ailoy is a lightweight library for building AI applications",
-    metadata: {
-        topic: "Ailoy",
-    },
+    metadata: { topic: "Ailoy" },
   });
 
   // Search the most relevant items
@@ -210,9 +246,9 @@ async function main() {
 
   // Augment user query
   const prompt = `
-    Based on the provided contexts, try to answer user' question.
-    Context: ${items.map((item) => item.document)}
-    Question: ${query}
+      Based on the provided contexts, try to answer user' question.
+      Context: ${items.map((item) => item.document)}
+      Question: ${query}
   `;
 
   // Invoke agent
@@ -222,7 +258,9 @@ async function main() {
   process.stdout.write("\n");
 }
 ```
-</CodeTabs.Nodejs>
+
+</TabItem>
 </CodeTabs>
 
-> **Tip:** For best results, ensure your documents are chunked semantically (e.g., by paragraphs or sections).
+> **Tip:** For best results, ensure your documents are chunked semantically
+> (e.g., by paragraphs or sections).

--- a/docs/tutorial/rag-with-vector-store.mdx
+++ b/docs/tutorial/rag-with-vector-store.mdx
@@ -246,9 +246,9 @@ async function main() {
 
   // Augment user query
   const prompt = `
-      Based on the provided contexts, try to answer user' question.
-      Context: ${items.map((item) => item.document)}
-      Question: ${query}
+    Based on the provided contexts, try to answer user' question.
+    Context: ${items.map((item) => item.document)}
+    Question: ${query}
   `;
 
   // Invoke agent

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,64 +1,64 @@
-import {themes as prismThemes} from 'prism-react-renderer';
-import type {Config} from '@docusaurus/types';
-import type * as Preset from '@docusaurus/preset-classic';
+import type * as Preset from "@docusaurus/preset-classic";
+import type { Config } from "@docusaurus/types";
+import { themes as prismThemes } from "prism-react-renderer";
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 const config: Config = {
-  title: 'Ailoy',
-  tagline: 'Dinosaurs are cool',
-  favicon: 'img/favicon.ico',
+  title: "Ailoy",
+  tagline: "Dinosaurs are cool",
+  favicon: "img/favicon.ico",
 
   // Set the production url of your site here
-  url: 'https://your-docusaurus-site.example.com',
+  url: "https://your-docusaurus-site.example.com",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: "/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'facebook', // Usually your GitHub org/user name.
-  projectName: 'docusaurus', // Usually your repo name.
+  organizationName: "facebook", // Usually your GitHub org/user name.
+  projectName: "docusaurus", // Usually your repo name.
 
-  onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenLinks: "throw",
+  onBrokenMarkdownLinks: "warn",
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".
   i18n: {
-    defaultLocale: 'en',
-    locales: ['en'],
+    defaultLocale: "en",
+    locales: ["en"],
   },
 
   presets: [
     [
-      'classic',
+      "classic",
       {
         docs: {
-          sidebarPath: './src/sidebars.ts',
+          sidebarPath: "./src/sidebars.ts",
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
         },
         blog: {
           showReadingTime: true,
           feedOptions: {
-            type: ['rss', 'atom'],
+            type: ["rss", "atom"],
             xslt: true,
           },
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
           // Useful options to enforce blogging best practices
-          onInlineTags: 'warn',
-          onInlineAuthors: 'warn',
-          onUntruncatedBlogPosts: 'warn',
+          onInlineTags: "warn",
+          onInlineAuthors: "warn",
+          onUntruncatedBlogPosts: "warn",
         },
         theme: {
-          customCss: './src/css/custom.css',
+          customCss: "./src/css/custom.css",
         },
       } satisfies Preset.Options,
     ],
@@ -66,67 +66,67 @@ const config: Config = {
 
   themeConfig: {
     // Replace with your project's social card
-    image: 'img/docusaurus-social-card.jpg',
+    image: "img/docusaurus-social-card.jpg",
     navbar: {
-      title: 'Ailoy',
+      title: "Ailoy",
       logo: {
-        alt: 'Ailoy Logo',
-        src: 'img/logo.svg',
+        alt: "Ailoy Logo",
+        src: "img/logo.svg",
       },
       items: [
         {
-          type: 'docSidebar',
-          sidebarId: 'documentSidebar',
-          position: 'left',
-          label: 'Documents',
+          type: "docSidebar",
+          sidebarId: "documentSidebar",
+          position: "left",
+          label: "Documents",
         },
-        {to: '/blog', label: 'Blog', position: 'left'},
+        { to: "/blog", label: "Blog", position: "left" },
         {
-          href: 'https://github.com/facebook/docusaurus',
-          label: 'GitHub',
-          position: 'right',
+          href: "https://github.com/facebook/docusaurus",
+          label: "GitHub",
+          position: "right",
         },
       ],
     },
     footer: {
-      style: 'dark',
+      style: "dark",
       links: [
         {
-          title: 'Docs',
+          title: "Docs",
           items: [
             {
-              label: 'Tutorial',
-              to: '/docs/tutorial/getting-started',
+              label: "Tutorial",
+              to: "/docs/tutorial/getting-started",
             },
           ],
         },
         {
-          title: 'Community',
+          title: "Community",
           items: [
             {
-              label: 'Stack Overflow',
-              href: 'https://stackoverflow.com/questions/tagged/docusaurus',
+              label: "Stack Overflow",
+              href: "https://stackoverflow.com/questions/tagged/docusaurus",
             },
             {
-              label: 'Discord',
-              href: 'https://discordapp.com/invite/docusaurus',
+              label: "Discord",
+              href: "https://discordapp.com/invite/docusaurus",
             },
             {
-              label: 'X',
-              href: 'https://x.com/docusaurus',
+              label: "X",
+              href: "https://x.com/docusaurus",
             },
           ],
         },
         {
-          title: 'More',
+          title: "More",
           items: [
             {
-              label: 'Blog',
-              to: '/blog',
+              label: "Blog",
+              to: "/blog",
             },
             {
-              label: 'GitHub',
-              href: 'https://github.com/brekkylab/ailoy',
+              label: "GitHub",
+              href: "https://github.com/brekkylab/ailoy",
             },
           ],
         },

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -10,15 +10,15 @@ const config: Config = {
   favicon: "img/favicon.ico",
 
   // Set the production url of your site here
-  url: "https://your-docusaurus-site.example.com",
+  url: "https://ailoy.co",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: "facebook", // Usually your GitHub org/user name.
-  projectName: "docusaurus", // Usually your repo name.
+  organizationName: "BrekkyLab", // Usually your GitHub org/user name.
+  projectName: "ailoy", // Usually your repo name.
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
@@ -37,26 +37,22 @@ const config: Config = {
       {
         docs: {
           sidebarPath: "./src/sidebars.ts",
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
         },
-        blog: {
-          showReadingTime: true,
-          feedOptions: {
-            type: ["rss", "atom"],
-            xslt: true,
-          },
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
-          // Useful options to enforce blogging best practices
-          onInlineTags: "warn",
-          onInlineAuthors: "warn",
-          onUntruncatedBlogPosts: "warn",
-        },
+        // blog: {
+        //   showReadingTime: true,
+        //   feedOptions: {
+        //     type: ["rss", "atom"],
+        //     xslt: true,
+        //   },
+        //   // Please change this to your repo.
+        //   // Remove this to remove the "edit this page" links.
+        //   editUrl:
+        //     "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+        //   // Useful options to enforce blogging best practices
+        //   onInlineTags: "warn",
+        //   onInlineAuthors: "warn",
+        //   onUntruncatedBlogPosts: "warn",
+        // },
         theme: {
           customCss: "./src/css/custom.css",
         },
@@ -82,7 +78,7 @@ const config: Config = {
         },
         { to: "/blog", label: "Blog", position: "left" },
         {
-          href: "https://github.com/facebook/docusaurus",
+          href: "https://github.com/brekkylab/ailoy",
           label: "GitHub",
           position: "right",
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@docusaurus/module-type-aliases": "3.7.0",
         "@docusaurus/tsconfig": "3.7.0",
         "@docusaurus/types": "3.7.0",
+        "@trivago/prettier-plugin-sort-imports": "^5.2.2",
         "typescript": "~5.6.2"
       },
       "engines": {
@@ -4351,6 +4352,41 @@
       },
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-5.2.2.tgz",
+      "integrity": "sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.7",
+        "@babel/traverse": "^7.26.7",
+        "@babel/types": "^7.26.7",
+        "javascript-natural-sort": "^0.7.1",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">18.12"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "3.x",
+        "prettier": "2.x - 3.x",
+        "prettier-plugin-svelte": "3.x",
+        "svelte": "4.x || 5.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/@trysound/sax": {
@@ -9616,6 +9652,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -14535,6 +14578,23 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-error": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@docusaurus/module-type-aliases": "3.7.0",
     "@docusaurus/tsconfig": "3.7.0",
     "@docusaurus/types": "3.7.0",
+    "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "typescript": "~5.6.2"
   },
   "browserslist": {

--- a/src/components/CodeTabs.tsx
+++ b/src/components/CodeTabs.tsx
@@ -1,54 +1,10 @@
-// src/components/CodeTabs.tsx
-import React, { ReactElement } from 'react';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
+import Tabs, { type Props as TabsProps } from "@theme/Tabs";
 
-type CodeTabProps = {
-  children: string;
-};
-
-type CodeTabComponent = React.FC<CodeTabProps> & {
-  displayName: string;
-  language: string;
-};
-
-function CodeTabs({ children }: { children: React.ReactNode }) {
-  const elements = React.Children.toArray(children)
-    .filter(React.isValidElement)
-    .filter(
-      (el): el is ReactElement<CodeTabProps> =>
-        typeof el.type === 'function' && 'language' in el.type
-    );
-
-  return (
-    <Tabs groupId="code-language">
-      {elements.map((child, index) => {
-        const type = child.type as CodeTabComponent;
-        const label = type.displayName ?? `Tab ${index + 1}`;
-        const language = type.language ?? 'plaintext';
-        const content = child.props.children;
-
-        return (
-          <TabItem key={label} value={label} label={label}>
-            <CodeBlock language={language}>{content}</CodeBlock>
-          </TabItem>
-        );
-      })}
-    </Tabs>
-  );
+function CodeTabs(props: TabsProps) {
+  return <Tabs groupId="code-language" {...props} />;
 }
 
-// Factory to create tab subcomponents with metadata
-function createCodeTab(label: string, language: string): CodeTabComponent {
-  const Component: CodeTabComponent = ({ children }) => <>{children}</>;
-  Component.displayName = label;
-  Component.language = language;
-  return Component;
-}
-
-// Attach pre-defined tab types
-CodeTabs.Python = createCodeTab('Python', 'python');
-CodeTabs.Nodejs = createCodeTab('Javascript(Node)', 'javascript');
+export const pythonTab = { value: "python", label: "Python" };
+export const nodeTab = { value: "node", label: "JavaScript (Node)" };
 
 export default CodeTabs;

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -1,18 +1,19 @@
-import type {ReactNode} from 'react';
-import clsx from 'clsx';
-import Heading from '@theme/Heading';
-import styles from './styles.module.css';
+import Heading from "@theme/Heading";
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+import styles from "./styles.module.css";
 
 type FeatureItem = {
   title: string;
-  Svg: React.ComponentType<React.ComponentProps<'svg'>>;
+  Svg: React.ComponentType<React.ComponentProps<"svg">>;
   description: ReactNode;
 };
 
 const FeatureList: FeatureItem[] = [
   {
-    title: 'Easy to Use',
-    Svg: require('@site/static/img/undraw_docusaurus_mountain.svg').default,
+    title: "Easy to Use",
+    Svg: require("@site/static/img/undraw_docusaurus_mountain.svg").default,
     description: (
       <>
         Docusaurus was designed from the ground up to be easily installed and
@@ -21,8 +22,8 @@ const FeatureList: FeatureItem[] = [
     ),
   },
   {
-    title: 'Focus on What Matters',
-    Svg: require('@site/static/img/undraw_docusaurus_tree.svg').default,
+    title: "Focus on What Matters",
+    Svg: require("@site/static/img/undraw_docusaurus_tree.svg").default,
     description: (
       <>
         Docusaurus lets you focus on your docs, and we&apos;ll do the chores. Go
@@ -31,8 +32,8 @@ const FeatureList: FeatureItem[] = [
     ),
   },
   {
-    title: 'Powered by React',
-    Svg: require('@site/static/img/undraw_docusaurus_react.svg').default,
+    title: "Powered by React",
+    Svg: require("@site/static/img/undraw_docusaurus_react.svg").default,
     description: (
       <>
         Extend or customize your website layout by reusing React. Docusaurus can
@@ -42,9 +43,9 @@ const FeatureList: FeatureItem[] = [
   },
 ];
 
-function Feature({title, Svg, description}: FeatureItem) {
+function Feature({ title, Svg, description }: FeatureItem) {
   return (
-    <div className={clsx('col col--4')}>
+    <div className={clsx("col col--4")}>
       <div className="text--center">
         <Svg className={styles.featureSvg} role="img" />
       </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,17 +1,17 @@
-import type {ReactNode} from 'react';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
-import Heading from '@theme/Heading';
+import Link from "@docusaurus/Link";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import HomepageFeatures from "@site/src/components/HomepageFeatures";
+import Heading from "@theme/Heading";
+import Layout from "@theme/Layout";
+import clsx from "clsx";
+import type { ReactNode } from "react";
 
-import styles from './index.module.css';
+import styles from "./index.module.css";
 
 function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext();
   return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
+    <header className={clsx("hero hero--primary", styles.heroBanner)}>
       <div className="container">
         <Heading as="h1" className="hero__title">
           {siteConfig.title}
@@ -20,7 +20,8 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/tutorial/getting-started">
+            to="/docs/tutorial/getting-started"
+          >
             Docusaurus Tutorial - 5min ⏱️
           </Link>
         </div>
@@ -30,11 +31,12 @@ function HomepageHeader() {
 }
 
 export default function Home(): ReactNode {
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      description="Description will go into a meta tag in <head />"
+    >
       <HomepageHeader />
       <main>
         <HomepageFeatures />

--- a/src/sidebars.ts
+++ b/src/sidebars.ts
@@ -1,4 +1,4 @@
-import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
+import type { SidebarsConfig } from "@docusaurus/plugin-content-docs";
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
@@ -15,19 +15,19 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
   documentSidebar: [
     {
-      type: 'category',
-      label: 'Tutorial',
+      type: "category",
+      label: "Tutorial",
       items: [
-        'tutorial/getting-started',
-        'tutorial/reasoning',
-        'tutorial/using-tools',
-        'tutorial/integrate-with-mcp',
-        'tutorial/calling-low-level-apis',
-        'tutorial/rag-with-vector-store',
+        "tutorial/getting-started",
+        "tutorial/reasoning",
+        "tutorial/using-tools",
+        "tutorial/integrate-with-mcp",
+        "tutorial/calling-low-level-apis",
+        "tutorial/rag-with-vector-store",
       ],
     },
-    'agent-response-format',
-    'tools',
+    "agent-response-format",
+    "tools",
   ],
 };
 


### PR DESCRIPTION
After struggling to create custom components to reduce the amount of duplicated codes, I found that Docusaurus Tabs expects that its direct children must be type of TabItem, which means it's not allowed to put another components which eventually returns TabItem. This is quite frustrating, but there's currently no viable solutions.
So I managed to switch back to using TabItem, but using predefined props to minimize the duplicated codes.

Also I added `.prettierrc.json` and `.vscode/settings.json` for auto formatting codes.