### PR TITLE
Add remark plugin for CodeTabs

### DIFF
--- a/docs/tutorial/calling-low-level-apis.mdx
+++ b/docs/tutorial/calling-low-level-apis.mdx
@@ -1,7 +1,3 @@
-import CodeTabs, { pythonTab, nodeTab } from "@site/src/components/CodeTabs";
-import TerminalBox from '@site/src/components/TerminalBox';
-import TabItem from "@theme/TabItem";
-
 import AiloyInternalSvg from "./img/ailoy-internal.svg";
 
 # Calling low-level APIs
@@ -12,7 +8,9 @@ compute-intensive tasks, such as LLM inference. The `Runtime` serves as a bridge
 between the user and the `VM`, delegating user requests to the `VM` and
 forwarding results back from the `VM` to the user.
 
-<AiloyInternalSvg style={{ width: "50%", height: "50%" }} />
+<p align="center">
+  <AiloyInternalSvg style={{ width: "50%", height: "50%" }} />
+</p>
 
 By using the `Runtime` directly, you can send requests to the `VM` yourself.
 This is useful when you need more advanced configuration or want to call APIs
@@ -28,9 +26,8 @@ For this example, we’ll use Lev Tolstoy’s
 the reference text.
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumber
+```python
 from ailoy import Runtime
 
 rt = Runtime()
@@ -50,13 +47,10 @@ print("*********************************************************")
 
 rt.stop()
 ```
-</TabItem>
-<TabItem {...nodeTab}>
 
-```typescript showLineNumbers
-import { readFile } from "fs/promises";
-
+```typescript
 import { startRuntime } from "ailoy-node";
+import { readFile } from "fs/promises";
 
 (async () => {
   const rt = await startRuntime();
@@ -77,8 +71,9 @@ import { startRuntime } from "ailoy-node";
 })();
 ```
 
-</TabItem>
 </CodeTabs>
+
+{/* prettier-ignore-start */}
 
 <TerminalBox>
 {`
@@ -107,7 +102,11 @@ By this time he had nearly reached the shrine at the bend of the road. Looking u
 
 He came closer, so that it was clearly visible. To his surprise it really was a man, alive or dead, sitting naked, leaning motionless against the shrine. Terror seized the shoemaker, and he thought, “Some one has killed him, stripped him, and left him there. If I meddle I shall surely get into trouble.”
 *********************************************************
+
 `}
+
 </TerminalBox>
+
+{/* prettier-ignore-end */}
 
 (TODO) See low-level API reference for details.

--- a/docs/tutorial/getting-started.mdx
+++ b/docs/tutorial/getting-started.mdx
@@ -1,15 +1,10 @@
-import CodeTabs, { pythonTab, nodeTab } from "@site/src/components/CodeTabs";
-import TerminalBox from '@site/src/components/TerminalBox';
-import TabItem from "@theme/TabItem";
-
 # Getting started
 
 The very first step to using Ailoy is to start a `Runtime`.
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 from ailoy import Runtime
 
 # The runtime must be started to use Ailoy
@@ -21,10 +16,7 @@ rt = Runtime()
 rt.stop()
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 import { startRuntime } from "ailoy-node";
 
 // The runtime must be started to use Ailoy
@@ -36,7 +28,6 @@ const rt = await startRuntime();
 await rt.stop();
 ```
 
-</TabItem>
 </CodeTabs>
 
 The `Runtime` contains Ailoy’s internal engine. Most of Ailoy’s functionalities
@@ -48,9 +39,8 @@ use the functionality of LLM effortlessly. In this example, we’ll use Alibaba'
 [qwen3](https://github.com/QwenLM/Qwen3) with on-device run.
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 from ailoy import Agent
 
 # Defines an agent.
@@ -63,10 +53,7 @@ agent = Agent(rt, model_name="qwen3-0.6b")
 agent.delete()
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 import { defineAgent } from "ailoy-node";
 
 // Defines an agent.
@@ -79,7 +66,6 @@ const agent = await defineAgent(rt, "qwen3-0.6b");
 await agent.delete();
 ```
 
-</TabItem>
 </CodeTabs>
 
 This process may take some time, as it involves downloading the model
@@ -88,19 +74,15 @@ method. The output is returned as an iterator that yields the LLM’s response.
 This can also be considered a single step in successive generation process.
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 # This is where the actual LLM call happens.
 for resp in agent.run("Please give me a short poem about AI"):
     print(resp.content, end='')
 print()
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 // This is where the actual LLM call happens
 for await (const resp of agent.run("Please give me a short poem about AI")) {
   process.stdout.write(`${resp.content}`);
@@ -108,16 +90,14 @@ for await (const resp of agent.run("Please give me a short poem about AI")) {
 process.stdout.write("\n");
 ```
 
-</TabItem>
 </CodeTabs>
 
 Then, you may see an output similar to this.
 
 <TerminalBox>
-In the heart of innovation, AI dreams take flight—
-With thoughts that spark and find their way to light.
-It learns and creates, no bound, no strain—
-A world of dreams, where dreams may be found.
+  In the heart of innovation, AI dreams take flight— With thoughts that spark
+  and find their way to light. It learns and creates, no bound, no strain— A
+  world of dreams, where dreams may be found.
 </TerminalBox>
 
 {/* prettier-ignore-start */}
@@ -134,9 +114,8 @@ All done! You've just activated an LLM. 🎉
 Putting it all together, the complete code looks like this:
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 from ailoy import Runtime, Agent
 
 # The runtime must be started to use Ailoy
@@ -148,7 +127,7 @@ agent = Agent(rt, model_name="qwen3-0.6b")
 
 # This is where the actual LLM call happens
 for resp in agent.run("Please give me a short poem about AI"):
-  print(resp.content, end='')
+    print(resp.content, end='')
 print()
 
 # Once the agent is no longer needed, it can be released
@@ -158,10 +137,7 @@ agent.delete()
 rt.stop()
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 import { startRuntime, defineAgent } from "ailoy-node";
 
 (async () => {
@@ -185,5 +161,4 @@ import { startRuntime, defineAgent } from "ailoy-node";
 })();
 ```
 
-</TabItem>
 </CodeTabs>

--- a/docs/tutorial/integrate-with-mcp.mdx
+++ b/docs/tutorial/integrate-with-mcp.mdx
@@ -1,6 +1,3 @@
-import CodeTabs, { pythonTab, nodeTab } from "@site/src/components/CodeTabs";
-import TabItem from "@theme/TabItem";
-
 # Integrate with MCP
 
 The **Model Context Protocol (MCP)** is an open protocol developed by Anthropic
@@ -16,9 +13,8 @@ Ailoy Agents can seamlessly integrate with existing MCP-compliant servers. For
 example, the following code connects to the official GitHub MCP server:
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 from mcp import StdioServerParameters
 
 agent.add_tools_from_mcp_server(
@@ -29,17 +25,13 @@ agent.add_tools_from_mcp_server(
 )
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 await agent.addToolsFromMcpServer({
   command: "npx",
   args: ["-y", "@modelcontextprotocol/server-github"],
 });
 ```
 
-</TabItem>
 </CodeTabs>
 
 This launches the GitHub MCP server as a subprocess using standard I/O for
@@ -52,19 +44,15 @@ Once the tools are registered, the agent can invoke them naturally through its
 `query()` method:
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 question = "Search the repository named brekkylab/ailoy and describe what it does based on its README.md."
 for resp in agent.query(question):
     print(resp.content, end='')
 print()
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 const question =
   "Search the repository named brekkylab/ailoy and describe what it does based on its README.md.";
 for await (const resp of agent.query(question)) {
@@ -73,7 +61,6 @@ for await (const resp of agent.query(question)) {
 process.stdout.write("\n");
 ```
 
-</TabItem>
 </CodeTabs>
 
 This demonstrates how the agent utilizes the GitHub MCP tools to search
@@ -87,9 +74,8 @@ Here is the full source code to set up an agent, connect it to the GitHub MCP
 server, and issue a query:
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 from ailoy import Runtime, Agent
 from mcp import StdioServerParameters
 
@@ -109,10 +95,7 @@ with Agent(rt, model_name="qwen3-8b") as agent:
     print()
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 import { startRuntime, createAgent } from "ailoy-node";
 
 (async () => {
@@ -134,7 +117,6 @@ import { startRuntime, createAgent } from "ailoy-node";
 })();
 ```
 
-</TabItem>
 </CodeTabs>
 
 {/* prettier-ignore-start */}

--- a/docs/tutorial/rag-with-vector-store.mdx
+++ b/docs/tutorial/rag-with-vector-store.mdx
@@ -1,6 +1,3 @@
-import CodeTabs, { pythonTab, nodeTab } from "@site/src/components/CodeTabs";
-import TabItem from "@theme/TabItem";
-
 # RAG with Vector Store
 
 **Retrieval-Augmented Generation (RAG)** is a useful method when you want to use
@@ -21,9 +18,8 @@ Ailoy simplifies the construction of RAG pipelines through its built-in
 To initialize a vector store:
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 from ailoy import Runtime
 from ailoy.vectorstore import VectorStore
 
@@ -32,17 +28,13 @@ with VectorStore(rt, "bge-m3", "faiss") as vs:
     ...
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 import { startRuntime, defineVectorStore } from "ailoy-node";
 
 const rt = await startRuntime();
 const vs = await defineVectorStore(rt, "bge-m3", "faiss");
 ```
 
-</TabItem>
 </CodeTabs>
 
 > Ailoy currently supports both
@@ -59,19 +51,15 @@ const vs = await defineVectorStore(rt, "bge-m3", "faiss");
 You can insert text along with optional metadata into the vector store:
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 vs.insert(
     "Ailoy is a lightweight library for building AI applications",
     metadata={"topic": "Ailoy"}
 )
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 await vs.insert({
   document: "Ailoy is a lightweight library for building AI applications",
   metadata: {
@@ -80,7 +68,6 @@ await vs.insert({
 });
 ```
 
-</TabItem>
 </CodeTabs>
 
 In practice, you should split large documents into smaller chunks before
@@ -88,29 +75,24 @@ inserting them. This improves retrieval quality. You may use any text-splitting
 tool (e.g.,
 [LangChain](https://python.langchain.com/docs/concepts/text_splitters/)), or
 utilize Ailoy’s low-level runtime API for text splitting. (See
-[Calling Low-Level APIs](./calling-low-level-apis.md) for more details.)
+[Calling Low-Level APIs](./calling-low-level-apis.mdx) for more details.)
 
 ### Retrieving Relevant Documents
 
 To retrieve documents similar to a given query:
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 query = "What is Ailoy?"
-items =vs.retrieve(query, top_k=5)
+items = vs.retrieve(query, top_k=5)
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 const query = "What is Ailoy?";
 const items = await vs.retrieve(query, 5);
 ```
 
-</TabItem>
 </CodeTabs>
 
 This returns a list of `VectorStoreRetrieveItem` instances representing the most
@@ -123,9 +105,8 @@ Once documents are retrieved, you can construct a context-enriched prompt as
 follows:
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 prompt = f"""
     Based on the provided contexts, try to answer user's question.
     Context: {[item.document for item in items]}
@@ -133,10 +114,7 @@ prompt = f"""
 """
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 const prompt = `
   Based on the provided contexts, try to answer user' question.
   Context: ${items.map((item) => item.document)}
@@ -144,39 +122,32 @@ const prompt = `
 `;
 ```
 
-</TabItem>
 </CodeTabs>
 
 You can then pass this prompt to the agent for inference:
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 for resp in agent.run(prompt):
     print(resp.content, end='')
 print()
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 for await (const resp of agent.run(prompt)) {
   process.stdout.write(resp.content);
 }
 process.stdout.write("\n");
 ```
 
-</TabItem>
 </CodeTabs>
 
 ### Complete Example
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 from ailoy import Runtime, Agent, VectorStore
 
 # Initialize Runtime
@@ -194,7 +165,7 @@ with Agent(rt, "qwen3-8b") as agent, VectorStore(rt, "bge-m3", "faiss") as vs:
 
     # Search the most relevant items
     query = "What is Ailoy?"
-    items = vs.retrieve(query)
+    items = vs.retrieve(query, top_k=5)
 
     # Augment user query
     prompt = f"""
@@ -210,10 +181,7 @@ with Agent(rt, "qwen3-8b") as agent, VectorStore(rt, "bge-m3", "faiss") as vs:
 
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 import { createRuntime, defineAgent, defineVectorStore } from "ailoy-node";
 
 async function main() {
@@ -249,7 +217,6 @@ async function main() {
 }
 ```
 
-</TabItem>
 </CodeTabs>
 
 {/* prettier-ignore-start */}

--- a/docs/tutorial/reasoning.mdx
+++ b/docs/tutorial/reasoning.mdx
@@ -1,6 +1,3 @@
-import CodeTabs, { pythonTab, nodeTab } from "@site/src/components/CodeTabs";
-import TabItem from "@theme/TabItem";
-
 # Reasoning
 
 Reasoning is an advanced capability of AI that enables it to tackle complex
@@ -21,21 +18,17 @@ based on the complexity of your use case.
 In Ailoy, You can activate it by simply specifying an option:
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
-async for resp in agent.run(
-  "Please solve me a simultaneous equation: x+y=3, 4x+3y=12",
-  enable_reasoning=True
+```python
+for resp in agent.run(
+    "Please solve me a simultaneous equation: x+y=3, 4x+3y=12",
+    enable_reasoning=True
 ):
-  print(resp.content, end='')
+    print(resp.content, end='')
 print()
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 for await (const resp of agent.run(
   "Please solve me a simultaneous equation: x+y=3, 4x+3y=12",
   {
@@ -47,7 +40,6 @@ for await (const resp of agent.run(
 process.stdout.write("\n");
 ```
 
-</TabItem>
 </CodeTabs>
 
 Since reasoning is an internal process, you may not want to include it in the
@@ -55,22 +47,18 @@ output. In such cases, you can use the `ignore_reasoning` option to exclude it
 from the output.
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
-async for resp in agent.run(
-  "Please solve me a simultaneous equation: x+y=3, 4x+3y=12",
-  enable_reasoning=True,
-  ignore_reasoning_messages=True
+```python
+for resp in agent.run(
+    "Please solve me a simultaneous equation: x+y=3, 4x+3y=12",
+    enable_reasoning=True,
+    ignore_reasoning_messages=True
 ):
-  print(resp.content, end='')
+    print(resp.content, end='')
 print()
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 for await (const resp of agent.run(
   "Please solve me a simultaneous equation: x+y=3, 4x+3y=12",
   {
@@ -83,7 +71,6 @@ for await (const resp of agent.run(
 process.stdout.write("\n");
 ```
 
-</TabItem>
 </CodeTabs>
 
 {/* prettier-ignore-start */}

--- a/docs/tutorial/using-tools.mdx
+++ b/docs/tutorial/using-tools.mdx
@@ -1,7 +1,3 @@
-import CodeTabs, { pythonTab, nodeTab } from "@site/src/components/CodeTabs";
-import TabItem from "@theme/TabItem";
-import TerminalBox from '@site/src/components/TerminalBox';
-
 import ToolStructureSvg from "./img/tool-structure.svg";
 
 # Using tools
@@ -20,7 +16,9 @@ automation.
 Let's take a quick look at how tool calling works in general. In most agent
 system, tool calling can be achieved by the following process.
 
-<ToolStructureSvg style={{ width: "40%", height: "40%" }} />
+<p align="center">
+  <ToolStructureSvg style={{ width: "40%", height: "40%" }} />
+</p>
 
 - (1) \[Tool Description\] Assistant (or LLM) can recognize a tool based on its
   description (at it’s initialization).
@@ -40,46 +38,42 @@ rate lookup functionality.
 The first step is to define a tool.
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 rt = Runtime()
 agent = Agent(rt, model_name="qwen3-8b")
 
 frankfurter = {
-  "type": "restapi",
-  "description": {
-    "name": "frankfurter",
-    "description": "Get the latest currency exchange rates of target currencies based on the 'base' currency",
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "base": {
-                "type": "string",
-                "description": "The ISO 4217 currency code to be the divider of the currency rate to be got."
+    "type": "restapi",
+    "description": {
+        "name": "frankfurter",
+        "description": "Get the latest currency exchange rates of target currencies based on the 'base' currency",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "base": {
+                    "type": "string",
+                    "description": "The ISO 4217 currency code to be the divider of the currency rate to be got."
+                },
+                "symbols": {
+                    "type": "string",
+                    "description": "The target ISO 4217 currency codes separated by comma."
+                }
             },
-            "symbols": {
-                "type": "string",
-                "description": "The target ISO 4217 currency codes separated by comma."
-            }
-        },
-    }
-  },
-  "behavior": {
-    "baseURL": "https://api.frankfurter.dev/v1/latest",
-    "method": "GET",
-    "headers": {
-      "accept": "application/json"
-    }
-  },
+        }
+    },
+    "behavior": {
+        "baseURL": "https://api.frankfurter.dev/v1/latest",
+        "method": "GET",
+        "headers": {
+            "accept": "application/json"
+        }
+    },
 }
 agent.add_restapi_tool(frankfurter)
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 const rt = await startRuntime();
 const agent = await defineAgent(rt, { model: { name: "qwen3-8b" } });
 
@@ -112,10 +106,9 @@ const frankfurter = {
     },
   },
 };
-agent.add_restapi_tool(frankfurter);
+agent.addRESTAPITool(frankfurter);
 ```
 
-</TabItem>
 </CodeTabs>
 
 The `description` defines how the AI recognizes and understands the tool. In
@@ -138,47 +131,37 @@ tools, including the Frankfurter API.
 If you find a proper tool from preset, you can simply imports it into the agent:
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
 ```python
 agent.add_tools_from_preset("frankfurter")
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
 ```typescript
 agent.addToolsFromPreset("frankfurter");
 ```
 
-</TabItem>
 </CodeTabs>
 
 By calling `run` function, you can see that the agent uses the Frankfurters API
 to incorporate real-time exchange rate information into its response.
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 question = "I want to buy 250 U.S. Dollar and 350 Chinese Yuan with my Korean Won. How much do I need to take?"
-async for resp in agent.run(question):
+for resp in agent.run(question):
     print(resp.content, end='')
 print()
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 const question = "I want to buy 250 U.S. Dollar and 350 Chinese Yuan with my Korean Won. How much do I need to take?";
 for await (const resp in agent.run(question)) {
-    process.stdout.write(resp.content);
+  process.stdout.write(resp.content);
 }
 process.stdout.write("\n");
 ```
 
-</TabItem>
 </CodeTabs>
 
 Here's what the output will look like:
@@ -191,25 +174,34 @@ id='call_fe4b76ff-021c-409b-a835-df83b425f35e' type='function' function=ToolCall
 - **1 CNY = 0.00516 KRW**
 
 ### Step 1: Calculate KRW for USD
-$$ 250 \, \text{USD} \times \frac{1}{0.00072} = 250 \, \text{USD} \times 1388.89 \approx 347,222 \, \text{KRW} $$
+
+$$
+250 \, \text{USD} \times \frac{1}{0.00072} = 250 \, \text{USD} \times 1388.89
+\approx 347,222 \, \text{KRW}
+$$
 
 ### Step 2: Calculate KRW for CNY
-$$ 350 \, \text{CNY} \times \frac{1}{0.00516} = 350 \, \text{CNY} \times 193.88 \approx 67,858 \, \text{KRW} $$
+
+$$
+350 \, \text{CNY} \times \frac{1}{0.00516} = 350 \, \text{CNY} \times 193.88
+\approx 67,858 \, \text{KRW}
+$$
 
 ### Step 3: Add both amounts
+
 $$ 347,222 \, \text{KRW} + 67,858 \, \text{KRW} = 415,080 \, \text{KRW} $$
 
 ### Final Answer:
-You need approximately **415,080 Korean Won** to buy 250 USD and 350 CNY.
-`}
+
+You need approximately **415,080 Korean Won** to buy 250 USD and 350 CNY. `}
+
 </TerminalBox>
 
 ## Complete Example
 
 <CodeTabs>
-<TabItem {...pythonTab}>
 
-```python showLineNumbers
+```python
 from ailoy import Runtime, Agent
 
 rt = Runtime()
@@ -229,10 +221,7 @@ agent.delete()
 rt.stop()
 ```
 
-</TabItem>
-<TabItem {...nodeTab}>
-
-```typescript showLineNumbers
+```typescript
 import { startRuntime, defineAgent } from "ailoy-node";
 
 (async () => {
@@ -256,7 +245,6 @@ import { startRuntime, defineAgent } from "ailoy-node";
 })();
 ```
 
-</TabItem>
 </CodeTabs>
 
 {/* prettier-ignore-start */}

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -2,6 +2,8 @@ import type * as Preset from "@docusaurus/preset-classic";
 import type { Config } from "@docusaurus/types";
 import { themes as prismThemes } from "prism-react-renderer";
 
+import remarkCodeTabs from "./src/plugins/remark-code-tabs";
+
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 const config: Config = {
@@ -37,6 +39,7 @@ const config: Config = {
       {
         docs: {
           sidebarPath: "./src/sidebars.ts",
+          remarkPlugins: [remarkCodeTabs],
         },
         // blog: {
         //   showReadingTime: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "@docusaurus/tsconfig": "3.7.0",
         "@docusaurus/types": "3.7.0",
         "@trivago/prettier-plugin-sort-imports": "^5.2.2",
-        "typescript": "~5.6.2"
+        "typescript": "~5.6.2",
+        "unist-util-visit": "^5.0.0"
       },
       "engines": {
         "node": ">=18.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@docusaurus/tsconfig": "3.7.0",
     "@docusaurus/types": "3.7.0",
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
-    "typescript": "~5.6.2"
+    "typescript": "~5.6.2",
+    "unist-util-visit": "^5.0.0"
   },
   "browserslist": {
     "production": [

--- a/src/components/CodeTabs.tsx
+++ b/src/components/CodeTabs.tsx
@@ -1,10 +1,7 @@
-import Tabs, { type Props as TabsProps } from "@theme/Tabs";
+import React from "react";
 
-function CodeTabs(props: TabsProps) {
-  return <Tabs groupId="code-language" {...props} />;
+function CodeTabs({ children }) {
+  return <>{children}</>;
 }
-
-export const pythonTab = { value: "python", label: "Python" };
-export const nodeTab = { value: "node", label: "JavaScript (Node)" };
 
 export default CodeTabs;

--- a/src/components/TerminalBox.tsx
+++ b/src/components/TerminalBox.tsx
@@ -1,41 +1,68 @@
-import React from 'react';
+import React from "react";
 
-export default function TerminalBox({ children }: { children: React.ReactNode }) {
+export default function TerminalBox({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <div
       style={{
-        borderRadius: '10px',
-        overflow: 'hidden',
-        boxShadow: '0 0 10px rgba(0,0,0,0.2)',
-        fontFamily: 'Menlo, Consolas, monospace',
-        marginBottom: '1rem',
+        borderRadius: "10px",
+        overflow: "hidden",
+        boxShadow: "0 0 10px rgba(0,0,0,0.2)",
+        fontFamily: "Menlo, Consolas, monospace",
+        marginBottom: "1rem",
       }}
     >
       {/* Top bar with window control buttons */}
       <div
         style={{
-          background: '#ddd',
-          padding: '0.5rem',
-          display: 'flex',
-          gap: '0.5rem',
+          background: "#ddd",
+          padding: "0.5rem",
+          display: "flex",
+          gap: "0.5rem",
         }}
       >
-        <span style={{ width: '12px', height: '12px', background: '#ff5f56', borderRadius: '50%' }} />
-        <span style={{ width: '12px', height: '12px', background: '#ffbd2e', borderRadius: '50%' }} />
-        <span style={{ width: '12px', height: '12px', background: '#27c93f', borderRadius: '50%' }} />
+        <span
+          style={{
+            width: "12px",
+            height: "12px",
+            background: "#ff5f56",
+            borderRadius: "50%",
+          }}
+        />
+        <span
+          style={{
+            width: "12px",
+            height: "12px",
+            background: "#ffbd2e",
+            borderRadius: "50%",
+          }}
+        />
+        <span
+          style={{
+            width: "12px",
+            height: "12px",
+            background: "#27c93f",
+            borderRadius: "50%",
+          }}
+        />
       </div>
 
       {/* Scrollable terminal output area */}
       <pre
         style={{
-          background: '#1e1e1e',
-          color: '#d4d4d4',
+          background: "#1e1e1e",
+          color: "#d4d4d4",
           margin: 0,
-          padding: '1rem',
-          whiteSpace: 'pre-wrap',
-          fontSize: '0.9rem',
-          maxHeight: '500px', // Scroll after approx. 40 lines
-          overflowY: 'auto',
+          padding: "1rem",
+          whiteSpace: "pre-wrap",
+          fontSize: "0.9rem",
+          maxHeight: "500px", // Scroll after approx. 40 lines
+          overflowY: "auto",
+          borderTopLeftRadius: 0,
+          borderTopRightRadius: 0,
         }}
       >
         {children}

--- a/src/plugins/remark-code-tabs.js
+++ b/src/plugins/remark-code-tabs.js
@@ -1,0 +1,65 @@
+const { visit } = require("unist-util-visit");
+
+module.exports = function remarkCodeTabs() {
+  return (tree) => {
+    visit(tree, (node, index, parent) => {
+      if (node.type !== "mdxJsxFlowElement" || node.name !== "CodeTabs") return;
+
+      const codeNodes = node.children.filter((c) => c.type === "code");
+
+      const tabItems = codeNodes.map((codeNode) => {
+        const lang = codeNode.lang;
+
+        // Determine TabItem value and label
+        let tabValue;
+        let tabLabel;
+        if (lang === "typescript" || lang === "javascript") {
+          // TODO: Distinguish with Javascript(Web) after Emscripten is supported
+          tabValue = "node";
+          tabLabel = "JavaScript(Node)";
+        } else {
+          tabValue = lang;
+          tabLabel = lang.charAt(0).toUpperCase() + lang.slice(1);
+        }
+
+        // Add "showLineNumbers" in code meta
+        let meta = codeNode.meta;
+        if (meta === null) {
+          meta = "showLineNumbers";
+        } else if (!meta.includes("showLineNumbers")) {
+          meta += " showLineNumbers";
+        }
+
+        return {
+          type: "mdxJsxFlowElement",
+          name: "TabItem",
+          attributes: [
+            { type: "mdxJsxAttribute", name: "value", value: tabValue },
+            { type: "mdxJsxAttribute", name: "label", value: tabLabel },
+          ],
+          children: [
+            {
+              ...codeNode,
+              meta,
+            },
+          ],
+        };
+      });
+
+      const codeTabsNode = {
+        type: "mdxJsxFlowElement",
+        name: "Tabs",
+        attributes: [
+          {
+            type: "mdxJsxAttribute",
+            name: "groupId",
+            value: "code-language",
+          },
+        ],
+        children: tabItems,
+      };
+
+      parent.children[index] = codeTabsNode;
+    });
+  };
+};

--- a/src/theme/MDXComponents.tsx
+++ b/src/theme/MDXComponents.tsx
@@ -1,0 +1,15 @@
+import CodeTabs from "@site/src/components/CodeTabs";
+import TerminalBox from "@site/src/components/TerminalBox";
+import MDXComponents from "@theme-original/MDXComponents";
+import CodeBlock from "@theme/CodeBlock";
+import TabItem from "@theme/TabItem";
+import Tabs from "@theme/Tabs";
+
+export default {
+  ...MDXComponents,
+  CodeBlock,
+  Tabs,
+  TabItem,
+  CodeTabs,
+  TerminalBox,
+};


### PR DESCRIPTION
- Added remark plugin to search all `<CodeTabs>` elements and replace with Tabs and TabItems containing CodeBlock, with providing our desired attributes (such as `label` and `value` of TabItem, `showLineNumbers` of CodeBlock). In this way, we can significantly reduce duplicated codes in CodeTabs.
- Added `theme/MDXComponents.tsx` including our custom components (CodeTabs and TerminalBox), so we don't need to import them manually.
- Minor fixes related to code indents or API usages.